### PR TITLE
Moving HTTPS to Security Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,17 @@ For the purposes of these standards, we use the following definitions:
   * **Non Public APIs** - Available only to GSA applications and users.
   * **Public APIs** - Available to non-GSA applications and users. Examples include the general public, other agencies, or private companies.
 
+## API Security
+API Security is governed by the GSA IT Security Procedural Guide: API Security CIO-IT Security-19-93.
 
 ## Mandatory Items
 
 These are mandatory for existing and new APIs.
 
-### 1. Always Use HTTPS
-All APIs should require and use [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure) (using TLS/SSL). APIs should not allow HTTP connections.
-
-### 2. Add Your API To The GSA API Directory
+### 1. Add Your API To The GSA API Directory
 A directory of GSA public APIs is available at [open.gsa.gov/api](https://open.gsa.gov/api/). Add your API to this directory by posting an issue or pull request in the [GitHub repository](https://github.com/GSA/open-gsa-redesign). 
 
-### 3. Use The api.data.gov Service
+### 2. Use The api.data.gov Service
 
 The [api.data.gov service](https://api.data.gov/about/) is an API management service for federal agencies. GSA APIs should use the `api.gsa.gov` base domain with this service.  By having the `api.gsa.gov` base URL as a proxy to developers, this also makes it easier to update and maintain the API in the future since you can update the underlying system and URLs without exposing it to the public.  In some cases, other specific base domains can be established with this service for GSA APIs.
 
@@ -62,7 +61,7 @@ The api.gsa.gov service also provides:
 
 Keys managed by api.data.gov can be re-used with other APIs hosted by this service, which reduces complexity for users. This service also allows the use of a DEMO_KEY for unauthenticated access, without keys, which reduces the "Time To First Hello World" for developers using your API.
 
-### 4. Provide Support For Versioning
+### 3. Provide Support For Versioning
 All APIs must support versioning. The recommended method of versioning REST APIs is to include a major version number in the URL path. For example "/v1/". An example of this method can be found at: https://gsa.github.io/sam_api/sam/versioning.html.
 
 #### Major and Minor Versions
@@ -104,7 +103,7 @@ Leave at least one previous major version intact. And communicate to existing us
 #### Prototype or Alpha Versions
 Use "/v0/" to represent an API that is in prototype or alpha phase and is likely to change frequently without warning.
 
-### 5. Provide Public Documentation
+### 4. Provide Public Documentation
 The developer's entry point to your API will likely be the documentation that you provide. GSA has developed an [API Documentation Template](https://github.com/GSA/api-documentation-template) which can be re-used for your API. 
 
 Your API documentation should provide:
@@ -120,7 +119,7 @@ Additional nice-to-haves include:
 * Interactive documentation to demonstrate sample calls.
 * Sample client code for consuming the API in common languages.
 
-### 6. Provide A Feedback Mechanism That Is Clear and Monitored
+### 5. Provide A Feedback Mechanism That Is Clear and Monitored
 
 Have an obvious mechanism for clients to report issues and ask questions about the API. It is critical to respond to issues posted or queries submitted by developers. This demonstrates that the API can be counted on for production usage. If an immediate fix (or even a developer to investigate) is not readily available, respond anyway. Developers will be glad to know when you'll be able to take a look.
 
@@ -128,7 +127,7 @@ When using GitHub for an API's code or documentation, use the associated issue t
 
 If you don't have a support channel specific to your API, you can use the issue tracker at [GSA-APIs](https://github.com/GSA/GSA-APIs/issues). Be sure your support team subscribes to issues there.
 
-### 7. Provide An OpenAPI Specification File
+### 6. Provide An OpenAPI Specification File
 The API documentation should provide a clear link to the [API's OpenAPI Specification file](https://github.com/OAI/OpenAPI-Specification). This specification was formerly known as the Swagger specification. This specification file can be used by development or testing tools accessing your API. 
 
 Using Version 2.0 or later of the specification is recommended. Information about versions can be found here: [OpenAPI Specification Revision History](https://swagger.io/specification/#revisionHistory).
@@ -137,7 +136,7 @@ Using Version 2.0 or later of the specification is recommended. Information abou
 
 In addition to the mandatory items above, new APIs must also implement these.
 
-### 8. Follow The Standard API Endpoint Design
+### 7. Follow The Standard API Endpoint Design
 An "endpoint" is a combination of two things:
 
 * The verb (e.g. `GET` , `POST`, `PUT`, `PATCH`, `DELETE`)
@@ -157,9 +156,6 @@ An example would be:
 
 
 ## Other Considerations
-
-### API Security
-API Security is governed by the GSA IT Security Procedural Guide: API Security CIO-IT Security-19-93.
 
 ### Design for common use cases
 


### PR DESCRIPTION
Removed HTTPS as an item listed in the standards to avoid confusion or duplication. This is one of the items referenced in the GSA IT Security Procedural Guide.